### PR TITLE
08 s3保存画像をフロントで表示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 
 .history/
 .DS_Store
+.env

--- a/app/controllers/api/v1/image_texts_controller.rb
+++ b/app/controllers/api/v1/image_texts_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ImageTextsController < ApplicationController
   require 'mini_magick'
-  require 'base64' # 追加
+  require 'base64' 
 
   def preview
     image_text = ImageText.new(answer1: params[:image_text][:answer1], answer2: params[:image_text][:answer2], answer3: params[:image_text][:answer3])
@@ -9,26 +9,32 @@ class Api::V1::ImageTextsController < ApplicationController
     temp_image_path = Rails.root.join('tmp', 'temp_image.jpg')
     image.write(temp_image_path)
 
-    encoded_image = Base64.encode64(File.open(temp_image_path).read) # 追加
-    File.delete(temp_image_path) # 追加
+    encoded_image = Base64.encode64(File.open(temp_image_path).read)
+    File.delete(temp_image_path)
 
-    render json: { url: "data:image/jpg;base64,#{encoded_image}" } # 変更
+    render json: { url: "data:image/jpg;base64,#{encoded_image}" } 
   end
 
   def create
     image_text = ImageText.new(answer1: params[:image_text][:answer1], answer2: params[:image_text][:answer2], answer3: params[:image_text][:answer3])
-    image = generate_image(image_text)
-
-    temp_image_path = Rails.root.join('tmp', 'temp_image.jpg')
-    image.write(temp_image_path)
-
-    image_text.image.attach(io: File.open(temp_image_path), filename: 'temp_image.jpg')
-
+  
+    # まずは ImageText オブジェクトを保存
     if image_text.save
-      File.delete(temp_image_path) # 追加
-      render json: { url: url_for(image_text.image), id: image_text.id } # Include id in the response
+      begin
+        # 例外が発生する可能性のあるコードを begin-end ブロック内に配置
+        image = generate_image(image_text)
+        temp_image_path = Rails.root.join('tmp', 'temp_image.jpg')
+        image.write(temp_image_path)
+        
+        image_text.image.attach(io: File.open(temp_image_path), filename: 'temp_image.jpg')
+        File.delete(temp_image_path)
+        
+        render json: { url: url_for(image_text.image), id: image_text.id }
+      rescue => e
+        # 何か問題が発生した場合は、そのエラーを捕捉し、エラーメッセージを返す
+        render json: { errors: [e.message] }, status: :internal_server_error
+      end
     else
-      File.delete(temp_image_path) # 追加
       render json: { errors: image_text.errors.full_messages }, status: :unprocessable_entity
     end
   end

--- a/app/controllers/api/v1/image_texts_controller.rb
+++ b/app/controllers/api/v1/image_texts_controller.rb
@@ -47,9 +47,10 @@ class Api::V1::ImageTextsController < ApplicationController
   end
   
   def show
-    image_text = ImageText.find(params[:id])
+    image_text = 
+    ImageText.find(params[:id])
     if image_text
-      render json: { image_url: image_text.image_url }
+      render json: { image_url: image_text.image_url, id: image_text.id  }
     else
       render json: { error: "Image not found" }, status: :not_found
     end

--- a/app/controllers/api/v1/image_texts_controller.rb
+++ b/app/controllers/api/v1/image_texts_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::ImageTextsController < ApplicationController
   require 'base64' # 追加
 
   def preview
-    image_text = ImageText.new(answer1: params[:answer1], answer2: params[:answer2], answer3: params[:answer3])
+    image_text = ImageText.new(answer1: params[:image_text][:answer1], answer2: params[:image_text][:answer2], answer3: params[:image_text][:answer3])
     image = generate_image(image_text)
 
     temp_image_path = Rails.root.join('tmp', 'temp_image.jpg')
@@ -16,7 +16,7 @@ class Api::V1::ImageTextsController < ApplicationController
   end
 
   def create
-    image_text = ImageText.new(answer1: params[:answer1], answer2: params[:answer2], answer3: params[:answer3])
+    image_text = ImageText.new(answer1: params[:image_text][:answer1], answer2: params[:image_text][:answer2], answer3: params[:image_text][:answer3])
     image = generate_image(image_text)
 
     temp_image_path = Rails.root.join('tmp', 'temp_image.jpg')

--- a/app/controllers/api/v1/image_texts_controller.rb
+++ b/app/controllers/api/v1/image_texts_controller.rb
@@ -33,6 +33,15 @@ class Api::V1::ImageTextsController < ApplicationController
     end
   end
 
+  def show
+    image_text = ImageText.find(params[:id])
+    if image_text
+      render json: { url: url_for(image_text.image) }
+    else
+      render json: { error: "Image not found" }, status: :not_found
+    end
+  end
+
   private
 
   def generate_image(image_text)

--- a/app/controllers/api/v1/image_texts_controller.rb
+++ b/app/controllers/api/v1/image_texts_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::ImageTextsController < ApplicationController
 
     if image_text.save
       File.delete(temp_image_path) # 追加
-      render json: { url: url_for(image_text.image) }
+      render json: { url: url_for(image_text.image), id: image_text.id } # Include id in the response
     else
       File.delete(temp_image_path) # 追加
       render json: { errors: image_text.errors.full_messages }, status: :unprocessable_entity

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :image_text, only: [:create, :show]
+      resources :image_texts, only: [:create, :show]
       post '/image_texts/preview', to: 'image_texts#preview'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,8 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :users
+      resources :image_text, only: [:create, :show]
       post '/image_texts/preview', to: 'image_texts#preview'
-      post '/image_texts',         to: 'image_texts#create'
-      get  '/image_texts',         to: 'image_texts#show'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :users
       post '/image_texts/preview', to: 'image_texts#preview'
-      post '/image_texts', to: 'image_texts#create'
+      post '/image_texts',         to: 'image_texts#create'
+      get  '/image_texts',         to: 'image_texts#show'
     end
   end
 end

--- a/db/migrate/20230523123201_create_image_texts.rb
+++ b/db/migrate/20230523123201_create_image_texts.rb
@@ -4,6 +4,7 @@ class CreateImageTexts < ActiveRecord::Migration[6.1]
       t.string :answer1
       t.string :answer2
       t.string :answer3
+      t.string :image_url, null: false
 
       t.timestamps
     end

--- a/db/migrate/20230527081038_add_image_url_to_image_text.rb
+++ b/db/migrate/20230527081038_add_image_url_to_image_text.rb
@@ -1,0 +1,7 @@
+class AddImageUrlToImageText < ActiveRecord::Migration[6.1]
+  def change
+    def change
+      add_column :image_texts, :image_url, :string
+    end
+  end
+end

--- a/db/migrate/20230527081038_add_image_url_to_image_text.rb
+++ b/db/migrate/20230527081038_add_image_url_to_image_text.rb
@@ -1,7 +1,0 @@
-class AddImageUrlToImageText < ActiveRecord::Migration[6.1]
-  def change
-    def change
-      add_column :image_texts, :image_url, :string
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_23_123201) do
+ActiveRecord::Schema.define(version: 2023_05_27_081038) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_27_081038) do
+ActiveRecord::Schema.define(version: 2023_05_23_123201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2023_05_27_081038) do
     t.string "answer1"
     t.string "answer2"
     t.string "answer3"
+    t.string "image_url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
# 説明
フロント画面でフォームに値を入力して、作成ボタンを押したのちに
遷移先の画面で作成→S3に保存した画像をフロントで表示するように実装した。

# 確認したこと
ローカル環境でフロント画面でフォームに値を入力して、作成ボタンを押したのちに
遷移先の画面で作成→S3に保存した画像をフロントで表示できていることを確認した。