### PR TITLE
changind open_ranges_controllerのupdateメソッドのリファクタリング

### DIFF
--- a/app/controllers/api/v1/open_ranges_controller.rb
+++ b/app/controllers/api/v1/open_ranges_controller.rb
@@ -5,13 +5,7 @@ class Api::V1::OpenRangesController < ApplicationController
   def update
     begin
       ActiveRecord::Base.transaction do
-        if membered_communities_only?
-          @communities.each do |community|
-            unless @profile.open_ranges.exists?(community: community)
-              @profile.open_ranges.create!(community: community)
-            end
-          end
-        end
+        create_open_ranges_for_communities if membered_communities_only?
         @profile.update!(privacy: profile_params[:privacy])
       end
       render json: { status: 'SUCCESS', message: 'Loaded the user'}
@@ -45,5 +39,13 @@ class Api::V1::OpenRangesController < ApplicationController
 
   def membered_communities_only?
     params.dig(:profile, :privacy) == 'membered_communities_only'
+  end
+
+  def create_open_ranges_for_communities
+    @communities.each do |community|
+      unless @profile.open_ranges.exists?(community: community)
+        @profile.open_ranges.create!(community: community)
+      end
+    end
   end
 end


### PR DESCRIPTION
# 説明
open_rangesコントローラーのupdateアクションのネストが深かったため、
saveのロジックをprivateメソッドに切り出しました。

# 確認したこと
ローカルでは正常に動いていることを確認しています。
